### PR TITLE
make: Disable cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ clean:
 	-rm -rf package-scanner proto
 
 proto: $(PWD)/**/*.go $(PWD)/agent-plugins-grpc/proto/*.go
-	go build -buildvcs=false -v .
+	env CGO_ENABLED=0 go build -buildvcs=false -v .
 
 .PHONY: clean


### PR DESCRIPTION
Use the `CGO_ENABLED=0` env variable to ensure that we are not dynamically linking glibc.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>