### PR TITLE
Acquire a lock file when performing a scan

### DIFF
--- a/internal/deepfence/lock.go
+++ b/internal/deepfence/lock.go
@@ -1,0 +1,70 @@
+package deepfence
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+)
+
+const lockFilePath = "/var/lock/deepfence-package-scanner.lock"
+
+type Flock struct {
+	m sync.RWMutex
+}
+
+func NewFlock() *Flock {
+	return &Flock{}
+}
+
+func getBootId() ([]byte, error) {
+	bootId, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read boot id: %w", err)
+	}
+	return bootId, nil
+}
+
+// Acquires a shared lock on the file.
+func (f *Flock) LockFile() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	fd, err := os.OpenFile(lockFilePath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open the lock file: %w", err)
+	}
+	defer fd.Close()
+
+	bootId, err := getBootId()
+	if err != nil {
+		return err
+	}
+
+	file := os.NewFile(fd.Fd(), lockFilePath)
+	file.Write(bootId)
+
+	if err := syscall.Flock(int(fd.Fd()), syscall.LOCK_SH); err != nil {
+		return fmt.Errorf("failed to acquire the lock file: %w", err)
+	}
+
+	return nil
+}
+
+// Releases the lock on the file.
+func (f *Flock) UnlockFile() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	fd, err := os.OpenFile(lockFilePath, os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open the lock file: %w", err)
+	}
+	defer fd.Close()
+
+	if err := syscall.Flock(int(fd.Fd()), syscall.LOCK_UN); err != nil {
+		return fmt.Errorf("failed to unlock the lock file: %w", err)
+	}
+
+	return nil
+}

--- a/package-sbom/grpc.go
+++ b/package-sbom/grpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Jeffail/tunny"
+	"github.com/deepfence/package-scanner/internal/deepfence"
 	pb "github.com/deepfence/package-scanner/proto"
 	"github.com/deepfence/package-scanner/util"
 	log "github.com/sirupsen/logrus"
@@ -135,6 +136,14 @@ func processSbomGeneration(configInterface interface{}) interface{} {
 		log.Error("Error processing grpc input for generating SBOM")
 		return nil
 	}
+
+	flock := deepfence.NewFlock()
+	if err := flock.LockFile(); err != nil {
+		log.Error(err.Error())
+		return nil
+	}
+	defer flock.UnlockFile()
+
 	_, err := GenerateSBOM(config)
 	if err != nil {
 		log.Error("error in generating sbom: " + err.Error())

--- a/package-sbom/http-server.go
+++ b/package-sbom/http-server.go
@@ -3,12 +3,14 @@ package package_sbom
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Jeffail/tunny"
-	"github.com/deepfence/package-scanner/util"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"strconv"
+
+	"github.com/Jeffail/tunny"
+	"github.com/deepfence/package-scanner/internal/deepfence"
+	"github.com/deepfence/package-scanner/util"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -71,6 +73,14 @@ func processRegistryMessage(rInterface interface{}) interface{} {
 		KubernetesClusterName: r.KubernetesClusterName,
 		RegistryId:            r.RegistryId,
 	}
+
+	flock := deepfence.NewFlock()
+	if err := flock.LockFile(); err != nil {
+		log.Error(err.Error())
+		return false
+	}
+	defer flock.UnlockFile()
+
 	_, err := GenerateSBOM(config)
 	if err != nil {
 		log.Errorf("Error processing SBOM: %s", err.Error())


### PR DESCRIPTION
The purpose of the lock file is to prevent upgrades when there is any scan in progress.