### PR TITLE
update table output columns

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -285,21 +285,23 @@ func (p *Publisher) SendScanResultToConsole(vulnerabilities []scanner.Vulnerabil
 
 func TableOutput(report *[]scanner.VulnerabilityScanReport) error {
 	table := tw.NewWriter(os.Stdout)
-	table.SetHeader([]string{"CVE ID", "Severity", "Package", "Description"})
+	table.SetHeader([]string{"CVE ID", "Severity", "CVE Type", "Package", "CVE link"})
 	table.SetHeaderLine(true)
 	table.SetBorder(true)
 	table.SetAutoWrapText(true)
 	table.SetAutoFormatHeaders(true)
-	table.SetColMinWidth(0, 15)
-	table.SetColMinWidth(1, 15)
+	table.SetColMinWidth(0, 10)
+	table.SetColMinWidth(1, 10)
+	table.SetColMinWidth(3, 10)
 	table.SetColMinWidth(2, 15)
-	table.SetColMinWidth(3, 50)
+	table.SetColMinWidth(3, 15)
+	table.SetColumnAlignment([]int{tw.ALIGN_CENTER, tw.ALIGN_CENTER, tw.ALIGN_CENTER, tw.ALIGN_DEFAULT, tw.ALIGN_DEFAULT})
 
 	for _, r := range *report {
 		if r.CveCausedByPackage == "" {
 			r.CveCausedByPackage = r.CveCausedByPackagePath
 		}
-		table.Append([]string{r.CveId, r.CveSeverity, r.CveCausedByPackage, r.CveDescription})
+		table.Append([]string{r.CveId, r.CveSeverity, r.CveType, r.CveCausedByPackage, r.CveLink})
 	}
 	table.Render()
 	return nil


### PR DESCRIPTION
updated table output:

```
$ ./package-scanner --source . --container-runtime docker -scan-type golang-binary,golang
INFO[2023-09-07T08:00:34Z] run-once.go:88 scan id mahanth-tm-kafka_1694073634814       
summary:
 total=4 critical=0 high=0 medium=3 low=1

Most Exploitable Vulnerabilities:
+----------------+------------+-----------------+-----------------------------------------------------+----------------------------------------------------------+
|     CVE ID     |  SEVERITY  |    CVE TYPE     |                       PACKAGE                       |                         CVE LINK                         |
+----------------+------------+-----------------+-----------------------------------------------------+----------------------------------------------------------+
| CVE-2022-29526 |   medium   |     golang      | golang.org/x/sys:v0.0.0-20211006194710-c8a6f5223071 | https://www.cve.org/CVERecord?id=CVE-2022-29526          |
| CVE-2023-2253  |   medium   |     golang      | github.com/docker/distribution:v2.8.1+incompatible  | https://www.openwall.com/lists/oss-security/2023/05/09/1 |
+----------------+------------+-----------------+-----------------------------------------------------+----------------------------------------------------------+

Other Vulnerabilities:
+---------------+------------+-----------------+-------------------------------------+------------------------------------------------+
|    CVE ID     |  SEVERITY  |    CVE TYPE     |               PACKAGE               |                    CVE LINK                    |
+---------------+------------+-----------------+-------------------------------------+------------------------------------------------+
| CVE-2020-8911 |   medium   |     golang      | github.com/aws/aws-sdk-go:v1.44.285 | https://www.cve.org/CVERecord?id=CVE-2020-8911 |
| CVE-2020-8912 |    low     |     golang      | github.com/aws/aws-sdk-go:v1.44.285 | https://www.cve.org/CVERecord?id=CVE-2020-8912 |
+---------------+------------+-----------------+-------------------------------------+------------------------------------------------+

```