### PR TITLE
update syft and grype to latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye AS build
+FROM golang:1.21-bullseye AS build
 RUN apt-get clean && apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential git gcc libc-dev libffi-dev bash make apt-utils

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sirupsen/logrus v1.9.3
 	google.golang.org/grpc v1.58.2
-	google.golang.org/protobuf v1.31.0
 )
 
 require (
@@ -87,5 +86,6 @@ require (
 	golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 // indirect
 	google.golang.org/genproto v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/grype-bin/get_grype.sh
+++ b/tools/grype-bin/get_grype.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.63.0
+VERSION=0.72.0
 
 set -x -e
 

--- a/tools/syft-bin/get_syft.sh
+++ b/tools/syft-bin/get_syft.sh
@@ -5,7 +5,6 @@ set -x -e
 git clone https://github.com/deepfence/syft.git --branch optimise-resolver-2 || true
 cd syft/cmd/syft
 export CGO_ENABLED=0
-go mod vendor
 GOOS=linux GOARCH=amd64 go build -o syft_linux_amd64 .
 GOOS=linux GOARCH=arm64 go build -o syft_linux_arm64 .
 GOOS=darwin GOARCH=amd64 go build -o syft_darwin_amd64 .

--- a/tools/syft-bin/get_syft.sh
+++ b/tools/syft-bin/get_syft.sh
@@ -2,7 +2,7 @@
 
 set -x -e
 
-git clone https://github.com/deepfence/syft.git --branch optimise-resolver-1 || true
+git clone https://github.com/deepfence/syft.git --branch optimise-resolver-2 || true
 cd syft/cmd/syft
 export CGO_ENABLED=0
 go mod vendor


### PR DESCRIPTION
update syft and grype to latest stable release

syft version: [v0.94.0](https://github.com/anchore/syft/releases/tag/v0.94.0)
grype version:  [v0.72.0](https://github.com/anchore/grype/releases/tag/v0.72.0)