### PR TITLE
Use portable uname option

### DIFF
--- a/tools/grype-bin/get_grype.sh
+++ b/tools/grype-bin/get_grype.sh
@@ -5,7 +5,7 @@ set -eux
 VERSION=0.72.0
 
 HOST_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-HOST_ARCH=$(uname -p)
+HOST_ARCH=$(uname -m)
 
 if [ "$HOST_ARCH" = "x86_64" ]; then
     HOST_ARCH="amd64"

--- a/tools/syft-bin/get_syft.sh
+++ b/tools/syft-bin/get_syft.sh
@@ -3,7 +3,7 @@
 set -eux
 
 HOST_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-HOST_ARCH=$(uname -p)
+HOST_ARCH=$(uname -m)
 
 if [ "$HOST_ARCH" = "x86_64" ]; then
     HOST_ARCH="amd64"


### PR DESCRIPTION
Many linux distributions don't support -p.
Usage of -m seems widespread & is available in debian.