### PR TITLE
UPGRADE-GRYPE-0_73_1: Upgrading grype to 0.73.1 to include incorrect version comparisons fix

### DIFF
--- a/tools/grype-bin/get_grype.sh
+++ b/tools/grype-bin/get_grype.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-VERSION=0.72.0
+VERSION=0.73.1
 
 HOST_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH=$(uname -m)


### PR DESCRIPTION
Upgrading the grype to include the fix for the incorrect version comparisons
This will fix the issue seen with the incorrect vulnerabilities showing up on amazon linux scans.
